### PR TITLE
Add 3D graph toggle

### DIFF
--- a/PUNX.html
+++ b/PUNX.html
@@ -10,6 +10,7 @@
 <div id="searchContainer"><input id="searchInput" type="text" placeholder="Search node…"></div>
 <div id="infoPanel"></div>
 <div id="cy"></div>
+<div id="graph3d"></div>
 <script src="https://unpkg.com/cytoscape@3.23.0/dist/cytoscape.min.js"></script>
 <script src="https://unpkg.com/cytoscape-astar/cytoscape-astar.js"></script>
 <script src="data.js"></script>
@@ -17,6 +18,9 @@
 <script src="depthControl.js"></script>
 <script src="clusterControl.js"></script>
 <script src="showOnlyControl.js"></script>
+<script src="https://unpkg.com/three/build/three.min.js"></script>
+<script src="https://unpkg.com/3d-force-graph"></script>
+<script src="graph3d.js"></script>
 <script>
   // Wait for DOM and data.js to load, then initialize the graph
   window.addEventListener('DOMContentLoaded', function() {

--- a/graph3d.js
+++ b/graph3d.js
@@ -1,0 +1,64 @@
+// graph3d.js
+// Renders a 3-D force-directed graph using 3d-force-graph
+
+let fg = null;
+
+function ensure3DContainer() {
+  let c = document.getElementById('graph3d');
+  if (!c) {
+    c = document.createElement('div');
+    c.id = 'graph3d';
+    c.style.position = 'absolute';
+    c.style.top = '0';
+    c.style.left = '0';
+    c.style.width = '100vw';
+    c.style.height = '100vh';
+    c.style.display = 'none';
+    c.style.zIndex = '900';
+    document.body.appendChild(c);
+  }
+  return c;
+}
+
+function cyTo3DData(cy) {
+  const nodes = cy.nodes().map(n => ({
+    id: n.id(),
+    type: n.data('type'),
+    years: n.data('years'),
+    color: n.style('background-color') || (n.data('type') === 'band' ? '#2E86AB' : '#E67E22')
+  }));
+  const links = cy.edges().map(e => ({
+    source: e.data('source'),
+    target: e.data('target'),
+    color: e.style('line-color') || '#cccccc'
+  }));
+  return { nodes, links };
+}
+
+function init3DGraph(data) {
+  const container = ensure3DContainer();
+  fg = ForceGraph3D()(container)
+    .nodeId('id')
+    .nodeLabel('id')
+    .nodeColor(d => d.color)
+    .linkColor(l => l.color)
+    .linkDirectionalArrowLength(3)
+    .linkDirectionalArrowRelPos(1);
+  fg.graphData({ nodes: data.nodes, links: data.links });
+}
+
+window.graph3D = {
+  show(cy) {
+    const container = ensure3DContainer();
+    const data = cyTo3DData(cy);
+    if (!fg) init3DGraph(data);
+    else fg.graphData({ nodes: data.nodes, links: data.links });
+    container.style.display = 'block';
+    fg.resumeAnimation();
+  },
+  hide() {
+    const container = document.getElementById('graph3d');
+    if (container) container.style.display = 'none';
+    if (fg) fg.pauseAnimation();
+  }
+};

--- a/showOnlyControl.js
+++ b/showOnlyControl.js
@@ -2,6 +2,8 @@
 // Handles the 'Show Only Highlighted' button functionality
 
 let showOnly = false;
+let is3DView = false;
+let cyRef = null;
 
 // showOnlyControl.js
 
@@ -46,6 +48,9 @@ function addShowOnlyControls(container) {
   controlGroup.style.gap = '6px';
 
   controlGroup.innerHTML = `
+    <button id="toggle3dBtn" style="padding: 7px 12px; background: #9C27B0; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: bold; font-size: 11px; white-space: nowrap; width: 100%;">
+      3D View
+    </button>
     <button id="showOnlyBtn" style="padding: 7px 12px; background: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: bold; font-size: 11px; white-space: nowrap; width: 100%;">
       Show Only Clusters
     </button>
@@ -66,12 +71,29 @@ function createShowOnlyUI() {
 }
 
 function initShowOnlyControl(cy) {
+  cyRef = cy;
   createShowOnlyUI();
   
   // Setup event handlers
+  const toggle3dBtn = document.getElementById('toggle3dBtn');
   const showBtn = document.getElementById('showOnlyBtn');
   const clearBtn = document.getElementById('clearHighlightsBtn');
   const clearClustersBtn = document.getElementById('clearClustersBtn');
+
+  if (toggle3dBtn) {
+    toggle3dBtn.onclick = function() {
+      is3DView = !is3DView;
+      if (is3DView) {
+        if (window.graph3D) window.graph3D.show(cyRef);
+        document.getElementById('cy').style.display = 'none';
+        toggle3dBtn.textContent = '2D View';
+      } else {
+        if (window.graph3D) window.graph3D.hide();
+        document.getElementById('cy').style.display = 'block';
+        toggle3dBtn.textContent = '3D View';
+      }
+    };
+  }
   
   if (showBtn) {
     showBtn.onclick = function() {

--- a/styles.css
+++ b/styles.css
@@ -1,6 +1,7 @@
 /* styles.css */
 body { margin: 0; font-family: Arial, sans-serif; }
 #cy { width: 100vw; height: 100vh; position: absolute; top: 0; left: 0; }
+#graph3d { width: 100vw; height: 100vh; position: absolute; top: 0; left: 0; display: none; }
 #infoPanel {
   position: absolute;
   top: 10px;


### PR DESCRIPTION
## Summary
- add new 3D force graph implementation (`graph3d.js`)
- create a toggle button for switching between 2‑D Cytoscape and 3‑D view
- style and add container for the 3‑D graph
- include required scripts in the HTML

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_6887007d7a1c832ca04edfab0430f3a4