### PR TITLE
Refactor controls, add styles

### DIFF
--- a/clusterControl.js
+++ b/clusterControl.js
@@ -1,136 +1,116 @@
-// clusterControl.js
-// Handles clustering of highlighted nodes
+(function(global){
+  // clusterControl.js
+  // Handles clustering of highlighted nodes
 
-let clusters = [];
-let clusterColors = [];
-let selectedClusterColor = null;
+  const clusters = [];
+  const clusterColors = [];
+  let selectedClusterColor = null;
 
-function getRandomColor() {
-  const h = Math.floor(Math.random() * 360);
-  return `hsl(${h}, 70%, 75%)`;
-}
-
-function createClusterUI() {
-  let panel = document.getElementById('clusterPanel');
-  if (!panel) {
-    panel = document.createElement('div');
-    panel.id = 'clusterPanel';
-    panel.style.position = 'absolute';
-    panel.style.top = '60px'; // Align with main control panel
-    panel.style.left = '180px'; // Position next to the main panel
-    panel.style.zIndex = 1005;
-    panel.style.background = 'rgba(255,255,255,0.95)';
-    panel.style.padding = '10px';
-    panel.style.borderRadius = '8px';
-    panel.style.boxShadow = '0 2px 12px rgba(0,0,0,0.1)';
-    panel.style.border = '1px solid #ddd';
-    panel.style.display = 'none'; // Initially hidden
-    panel.style.minWidth = '220px';
-    document.body.appendChild(panel);
+  function getRandomColor() {
+    const h = Math.floor(Math.random() * 360);
+    return `hsl(${h}, 70%, 75%)`;
   }
-  
-  panel.innerHTML = `
-    <div style="margin-bottom: 10px; font-weight: bold; color: #333;">Create Cluster</div>
-    <div style="margin-bottom: 10px;">
-      <label style="display: block; margin-bottom: 5px; font-size: 12px; color: #666;">Cluster Color:</label>
-      <div style="display: flex; gap: 5px; margin-bottom: 5px;">
-        <input type="color" id="clusterColorPicker" value="#FFD700" style="width: 40px; height: 30px; border: none; border-radius: 4px; cursor: pointer;">
-        <button id="randomColorBtn" style="padding: 5px 10px; background: #f0f0f0; border: 1px solid #ccc; border-radius: 4px; cursor: pointer; font-size: 11px;">Random</button>
-      </div>
-    </div>
-    <div style="display: flex; gap: 5px;">
-      <button id="createClusterBtn" style="flex: 1; padding: 8px 12px; background: #4CAF50; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: bold;">Create Cluster</button>
-      <button id="cancelClusterBtn" style="padding: 8px 12px; background: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer;">Cancel</button>
-    </div>
-  `;
-  
-  // Add event listeners
-  const colorPicker = document.getElementById('clusterColorPicker');
-  const randomBtn = document.getElementById('randomColorBtn');
-  const createBtn = document.getElementById('createClusterBtn');
-  const cancelBtn = document.getElementById('cancelClusterBtn');
-  
-  randomBtn.onclick = () => {
-    const randomColor = getRandomColor();
-    // Convert HSL to hex for color picker
-    const tempDiv = document.createElement('div');
-    tempDiv.style.color = randomColor;
-    document.body.appendChild(tempDiv);
-    const computedColor = window.getComputedStyle(tempDiv).color;
-    document.body.removeChild(tempDiv);
-    
-    // Simple random hex color instead
-    const hexColor = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
-    colorPicker.value = hexColor;
-  };
-  
-  cancelBtn.onclick = () => {
-    hideClusterButton();
-  };
-  
-  return panel;
-}
 
-function showClusterButton() {
-  const panel = createClusterUI();
-  panel.style.display = 'block';
-}
-
-function hideClusterButton() {
-  const panel = document.getElementById('clusterPanel');
-  if (panel) panel.style.display = 'none';
-}
-
-// Create a persistent cluster from highlighted nodes, updating nodeClusters and focusedClusterIdx
-function createCluster(cy, nodeClusters, clusters, clusterColors, setFocusedClusterIdx, customColor = null) {
-  const highlighted = cy.nodes('.highlight');
-  if (highlighted.length === 0) return;
-  
-  // Use custom color if provided, otherwise get random color
-  const color = customColor || getRandomColor();
-  const clusterIdx = clusters.length;
-  
-  // Store node references
-  const nodes = highlighted.toArray();
-  clusters.push({ nodes, color, clusterIdx });
-  clusterColors.push(color);
-  
-  // Update nodeClusters for each node
-  nodes.forEach(n => {
-    if (!nodeClusters[n.id()]) nodeClusters[n.id()] = [];
-    nodeClusters[n.id()].push({ color, clusterIdx });
-    n.addClass('cluster-color');
-    n.data('clusterColor', color);
-    n.style('background-color', color);
-  });
-  
-  // Set the focused cluster to the new one
-  if (typeof setFocusedClusterIdx === 'function') setFocusedClusterIdx(clusterIdx);
-  
-  // Hide the cluster panel after creating
-  hideClusterButton();
-  
-  console.log(`Created cluster ${clusterIdx} with ${nodes.length} nodes in color ${color}`);
-}
-
-// Setup event handlers for cluster creation
-function setupClusterEvents(cy, nodeClusters, clusters, clusterColors, setFocusedClusterIdx, updateNodeColors) {
-  // This will be called from main.js to setup the event handlers
-  document.addEventListener('click', function(e) {
-    if (e.target && e.target.id === 'createClusterBtn') {
-      const colorPicker = document.getElementById('clusterColorPicker');
-      const selectedColor = colorPicker ? colorPicker.value : null;
-      createCluster(cy, nodeClusters, clusters, clusterColors, setFocusedClusterIdx, selectedColor);
-      if (updateNodeColors) updateNodeColors();
+  function createClusterUI() {
+    let panel = document.getElementById('clusterPanel');
+    if (!panel) {
+      panel = document.createElement('div');
+      panel.id = 'clusterPanel';
+      panel.className = 'panel cluster-panel';
+      panel.style.top = '60px';
+      panel.style.left = '180px';
+      panel.style.display = 'none';
+      document.body.appendChild(panel);
     }
-  });
-}
 
-window.clusterControl = {
-  show: showClusterButton,
-  hide: hideClusterButton,
-  createCluster: createCluster,
-  setupEvents: setupClusterEvents,
-  clusters: clusters,
-  clusterColors: clusterColors
-};
+    panel.innerHTML = `
+      <div class="panel-header">Create Cluster</div>
+      <div style="margin-bottom:10px;">
+        <label style="display:block;margin-bottom:5px;font-size:12px;color:#666;">Cluster Color:</label>
+        <div style="display:flex;gap:5px;margin-bottom:5px;">
+          <input type="color" id="clusterColorPicker" value="#FFD700" style="width:40px;height:30px;border:none;border-radius:4px;cursor:pointer;">
+          <button id="randomColorBtn" class="btn btn-default">Random</button>
+        </div>
+      </div>
+      <div style="display:flex;gap:5px;">
+        <button id="createClusterBtn" class="btn btn-green" style="flex:1;">Create Cluster</button>
+        <button id="cancelClusterBtn" class="btn btn-red">Cancel</button>
+      </div>
+    `;
+
+    const colorPicker = document.getElementById('clusterColorPicker');
+    const randomBtn = document.getElementById('randomColorBtn');
+    const cancelBtn = document.getElementById('cancelClusterBtn');
+
+    randomBtn.onclick = () => {
+      const randomColor = getRandomColor();
+      const tempDiv = document.createElement('div');
+      tempDiv.style.color = randomColor;
+      document.body.appendChild(tempDiv);
+      const computedColor = window.getComputedStyle(tempDiv).color;
+      document.body.removeChild(tempDiv);
+      const hexColor = '#' + Math.floor(Math.random()*16777215).toString(16).padStart(6, '0');
+      colorPicker.value = hexColor;
+    };
+
+    cancelBtn.onclick = () => {
+      hideClusterButton();
+    };
+
+    return panel;
+  }
+
+  function showClusterButton() {
+    const panel = createClusterUI();
+    panel.style.display = 'block';
+  }
+
+  function hideClusterButton() {
+    const panel = document.getElementById('clusterPanel');
+    if (panel) panel.style.display = 'none';
+  }
+
+  function createCluster(cy, nodeClusters, clustersArr, colorsArr, setFocusedClusterIdx, customColor = null) {
+    const highlighted = cy.nodes('.highlight');
+    if (highlighted.length === 0) return;
+    const color = customColor || getRandomColor();
+    const clusterIdx = clustersArr.length;
+
+    const nodes = highlighted.toArray();
+    clustersArr.push({ nodes, color, clusterIdx });
+    colorsArr.push(color);
+
+    nodes.forEach(n => {
+      if (!nodeClusters[n.id()]) nodeClusters[n.id()] = [];
+      nodeClusters[n.id()].push({ color, clusterIdx });
+      n.addClass('cluster-color');
+      n.data('clusterColor', color);
+      n.style('background-color', color);
+    });
+
+    if (typeof setFocusedClusterIdx === 'function') setFocusedClusterIdx(clusterIdx);
+    hideClusterButton();
+    console.log(`Created cluster ${clusterIdx} with ${nodes.length} nodes in color ${color}`);
+  }
+
+  function setupClusterEvents(cy, nodeClusters, clustersArr, colorsArr, setFocusedClusterIdx, updateNodeColors) {
+    document.addEventListener('click', function(e) {
+      if (e.target && e.target.id === 'createClusterBtn') {
+        const colorPicker = document.getElementById('clusterColorPicker');
+        const selectedColor = colorPicker ? colorPicker.value : null;
+        createCluster(cy, nodeClusters, clustersArr, colorsArr, setFocusedClusterIdx, selectedColor);
+        if (updateNodeColors) updateNodeColors();
+      }
+    });
+  }
+
+  global.clusterControl = {
+    show: showClusterButton,
+    hide: hideClusterButton,
+    createCluster: createCluster,
+    setupEvents: setupClusterEvents,
+    clusters,
+    clusterColors
+  };
+})(window);
+

--- a/depthControl.js
+++ b/depthControl.js
@@ -1,92 +1,88 @@
-// depthControl.js
-// Handles +/- depth controls for highlight expansion/contraction
+(function(global){
+  // depthControl.js
+  // Handles +/- depth controls for highlight expansion/contraction
 
-let highlightSeedNode = null;
-let highlightDepth = 1;
-let highlightSet = new Set();
+  let highlightSeedNode = null;
+  let highlightDepth = 1;
 
-function showDepthControls() {
-  let controls = document.getElementById('depthControls');
-  if (!controls) {
-    controls = document.createElement('div');
-    controls.id = 'depthControls';
-    controls.style.position = 'absolute';
-    controls.style.top = '60px';
-    controls.style.left = '10px';
-    controls.style.zIndex = 1003;
-    controls.style.background = '#fff';
-    controls.style.border = '1px solid #aaa';
-    controls.style.borderRadius = '6px';
-    controls.style.padding = '4px 12px';
-    controls.style.boxShadow = '0 2px 8px rgba(0,0,0,0.10)';
-    controls.innerHTML = `
-      <button id="depthMinus" style="font-size:18px;width:32px;">-</button>
-      <span id="depthLevel" style="margin:0 8px;font-weight:bold;">1</span>
-      <button id="depthPlus" style="font-size:18px;width:32px;">+</button>
-    `;
-    document.body.appendChild(controls);
-  }
-  controls.style.display = 'block';
-  document.getElementById('depthLevel').textContent = highlightDepth;
-}
-
-function hideDepthControls() {
-  let controls = document.getElementById('depthControls');
-  if (controls) controls.style.display = 'none';
-}
-
-function getHighlightNodes(seed, depth) {
-  let visited = new Set([seed.id()]);
-  let currentLayer = [seed];
-  for (let d = 0; d < depth; d++) {
-    let nextLayer = [];
-    for (let node of currentLayer) {
-      node.neighborhood('node').forEach(n => {
-        if (!visited.has(n.id())) {
-          visited.add(n.id());
-          nextLayer.push(n);
-        }
-      });
+  function showDepthControls() {
+    let controls = document.getElementById('depthControls');
+    if (!controls) {
+      controls = document.createElement('div');
+      controls.id = 'depthControls';
+      controls.className = 'depth-controls';
+      controls.style.top = '60px';
+      controls.style.left = '10px';
+      controls.innerHTML = `
+        <button id="depthMinus" class="btn depth-btn">-</button>
+        <span id="depthLevel" style="margin:0 8px;font-weight:bold;">1</span>
+        <button id="depthPlus" class="btn depth-btn">+</button>
+      `;
+      document.body.appendChild(controls);
     }
-    currentLayer = nextLayer;
+    controls.style.display = 'block';
+    document.getElementById('depthLevel').textContent = highlightDepth;
   }
-  return Array.from(visited);
-}
 
-function updateHighlight(cy, seed, depth) {
-  cy.elements().removeClass('highlight faded');
-  let nodesToHighlight = getHighlightNodes(seed, depth);
-  nodesToHighlight.forEach(id => {
-    cy.getElementById(id).addClass('highlight');
-  });
-  cy.nodes().filter(n => !nodesToHighlight.includes(n.id())).addClass('faded');
-}
+  function hideDepthControls() {
+    let controls = document.getElementById('depthControls');
+    if (controls) controls.style.display = 'none';
+  }
 
-function setupDepthControls(cy) {
-  document.addEventListener('click', function(e) {
-    if (e.target && e.target.id === 'depthPlus') {
-      highlightDepth++;
-      document.getElementById('depthLevel').textContent = highlightDepth;
-      updateHighlight(cy, highlightSeedNode, highlightDepth);
+  function getHighlightNodes(seed, depth) {
+    let visited = new Set([seed.id()]);
+    let currentLayer = [seed];
+    for (let d = 0; d < depth; d++) {
+      let nextLayer = [];
+      for (let node of currentLayer) {
+        node.neighborhood('node').forEach(n => {
+          if (!visited.has(n.id())) {
+            visited.add(n.id());
+            nextLayer.push(n);
+          }
+        });
+      }
+      currentLayer = nextLayer;
     }
-    if (e.target && e.target.id === 'depthMinus') {
-      if (highlightDepth > 1) {
-        highlightDepth--;
+    return Array.from(visited);
+  }
+
+  function updateHighlight(cy, seed, depth) {
+    cy.elements().removeClass('highlight faded');
+    let nodesToHighlight = getHighlightNodes(seed, depth);
+    nodesToHighlight.forEach(id => {
+      cy.getElementById(id).addClass('highlight');
+    });
+    cy.nodes().filter(n => !nodesToHighlight.includes(n.id())).addClass('faded');
+  }
+
+  function setupDepthControls(cy) {
+    document.addEventListener('click', function(e) {
+      if (e.target && e.target.id === 'depthPlus') {
+        highlightDepth++;
         document.getElementById('depthLevel').textContent = highlightDepth;
         updateHighlight(cy, highlightSeedNode, highlightDepth);
       }
-    }
-  });
-}
-
-window.depthControl = {
-  show: showDepthControls,
-  hide: hideDepthControls,
-  setup: setupDepthControls,
-  setSeed: function(node, cy) {
-    highlightSeedNode = node;
-    highlightDepth = 1;
-    showDepthControls();
-    updateHighlight(cy, node, 1);
+      if (e.target && e.target.id === 'depthMinus') {
+        if (highlightDepth > 1) {
+          highlightDepth--;
+          document.getElementById('depthLevel').textContent = highlightDepth;
+          updateHighlight(cy, highlightSeedNode, highlightDepth);
+        }
+      }
+    });
   }
-};
+
+  global.depthControl = {
+    show: showDepthControls,
+    hide: hideDepthControls,
+    setup: setupDepthControls,
+    setSeed: function(node, cy) {
+      highlightSeedNode = node;
+      highlightDepth = 1;
+      showDepthControls();
+      updateHighlight(cy, node, 1);
+    }
+  };
+})(window);
+

--- a/showOnlyControl.js
+++ b/showOnlyControl.js
@@ -1,186 +1,131 @@
-// showOnlyControl.js
-// Handles the 'Show Only Highlighted' button functionality
+(function(global){
+  // showOnlyControl.js
+  // Handles the 'Show Only Highlighted' button functionality
 
-let showOnly = false;
+  let showOnly = false;
 
-// showOnlyControl.js
-
-// This function creates the main control panel and can be extended by other scripts.
-function createControlPanel() {
-  let container = document.getElementById('controlPanel');
-  if (!container) {
-    container = document.createElement('div');
-    container.id = 'controlPanel';
-    container.style.position = 'absolute';
-    container.style.top = '60px';
-    container.style.left = '10px';
-    container.style.zIndex = 1005;
-    container.style.background = 'rgba(255,255,255,0.95)';
-    container.style.padding = '10px';
-    container.style.borderRadius = '8px';
-    container.style.boxShadow = '0 2px 12px rgba(0,0,0,0.1)';
-    container.style.border = '1px solid #ddd';
-    container.style.minWidth = '160px';
-    document.body.appendChild(container);
-
-    // Add a header to the main panel
-    const header = document.createElement('div');
-    header.innerHTML = 'Controls';
-    header.style.fontSize = '12px';
-    header.style.fontWeight = 'bold';
-    header.style.color = '#333';
-    header.style.marginBottom = '8px';
-    header.style.textAlign = 'center';
-    header.style.borderBottom = '1px solid #eee';
-    header.style.paddingBottom = '5px';
-    container.appendChild(header);
+  function createControlPanel() {
+    let container = document.getElementById('controlPanel');
+    if (!container) {
+      container = document.createElement('div');
+      container.id = 'controlPanel';
+      container.className = 'panel';
+      container.style.top = '60px';
+      container.style.left = '10px';
+      const header = document.createElement('div');
+      header.className = 'panel-header';
+      header.innerHTML = 'Controls';
+      container.appendChild(header);
+      document.body.appendChild(container);
+    }
+    return container;
   }
-  return container;
-}
 
-// This function adds the specific controls for this module to the main panel
-function addShowOnlyControls(container) {
-  const controlGroup = document.createElement('div');
-  controlGroup.style.display = 'flex';
-  controlGroup.style.flexDirection = 'column';
-  controlGroup.style.gap = '6px';
+  function addShowOnlyControls(container) {
+    const controlGroup = document.createElement('div');
+    controlGroup.className = 'control-group';
+    controlGroup.innerHTML = `
+      <button id="showOnlyBtn" class="btn btn-blue btn-block">Show Only Clusters</button>
+      <button id="clearHighlightsBtn" class="btn btn-orange btn-block">Clear Highlights</button>
+      <button id="clearClustersBtn" class="btn btn-red btn-block">Clear All Clusters</button>
+    `;
+    container.appendChild(controlGroup);
+  }
 
-  controlGroup.innerHTML = `
-    <button id="showOnlyBtn" style="padding: 7px 12px; background: #2196F3; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: bold; font-size: 11px; white-space: nowrap; width: 100%;">
-      Show Only Clusters
-    </button>
-    <button id="clearHighlightsBtn" style="padding: 7px 12px; background: #FF9800; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: bold; font-size: 11px; white-space: nowrap; width: 100%;">
-      Clear Highlights
-    </button>
-    <button id="clearClustersBtn" style="padding: 7px 12px; background: #f44336; color: white; border: none; border-radius: 4px; cursor: pointer; font-weight: bold; font-size: 11px; white-space: nowrap; width: 100%;">
-      Clear All Clusters
-    </button>
-  `;
-  container.appendChild(controlGroup);
-}
+  function createShowOnlyUI() {
+    const container = createControlPanel();
+    addShowOnlyControls(container);
+    return container;
+  }
 
-function createShowOnlyUI() {
-  const container = createControlPanel();
-  addShowOnlyControls(container);
-  return container;
-}
+  function initShowOnlyControl(cy) {
+    createShowOnlyUI();
 
-function initShowOnlyControl(cy) {
-  createShowOnlyUI();
-  
-  // Setup event handlers
-  const showBtn = document.getElementById('showOnlyBtn');
-  const clearBtn = document.getElementById('clearHighlightsBtn');
-  const clearClustersBtn = document.getElementById('clearClustersBtn');
-  
-  if (showBtn) {
-    showBtn.onclick = function() {
-      showOnly = !showOnly;
-      if (showOnly) {
-        const highlighted = cy.nodes('.highlight');
-        const clustered = cy.nodes('.cluster-color');
-        const keep = highlighted.union(clustered);
-        cy.nodes().forEach(n => {
-          if (!keep.contains(n)) n.hide();
+    const showBtn = document.getElementById('showOnlyBtn');
+    const clearBtn = document.getElementById('clearHighlightsBtn');
+    const clearClustersBtn = document.getElementById('clearClustersBtn');
+
+    if (showBtn) {
+      showBtn.onclick = function() {
+        showOnly = !showOnly;
+        if (showOnly) {
+          const highlighted = cy.nodes('.highlight');
+          const clustered = cy.nodes('.cluster-color');
+          const keep = highlighted.union(clustered);
+          cy.nodes().forEach(n => { if (!keep.contains(n)) n.hide(); });
+          cy.edges().forEach(edge => { if (!edge.source().visible() || !edge.target().visible()) edge.hide(); });
+          showBtn.textContent = 'Show All';
+        } else {
+          cy.nodes().forEach(n => n.show());
+          cy.edges().forEach(e => e.show());
+          showBtn.textContent = 'Show Only Clusters';
+        }
+      };
+    }
+
+    if (clearBtn) {
+      clearBtn.onclick = function() {
+        cy.elements().removeClass('highlight faded');
+        cy.elements().style({ 'opacity': '', 'text-opacity': '' });
+
+        cy.nodes().forEach(node => { if (!node.hasClass('cluster-color')) node.style('background-color', ''); });
+        cy.edges().forEach(edge => { if (!edge.hasClass('cluster-color')) edge.style('line-color', ''); });
+
+        if (showOnly) {
+          cy.nodes().forEach(n => n.show());
+          cy.edges().forEach(e => e.show());
+          showOnly = false;
+          showBtn.textContent = 'Show Only Clusters';
+        }
+
+        const infoPanel = document.getElementById('infoPanel');
+        if (infoPanel) infoPanel.style.display = 'none';
+
+        const clusterPanel = document.getElementById('clusterPanel');
+        if (clusterPanel) clusterPanel.style.display = 'none';
+
+        console.log('Cleared highlights and temporary selections');
+      };
+    }
+
+    if (clearClustersBtn) {
+      clearClustersBtn.onclick = function() {
+        cy.elements().removeClass('highlight faded cluster-color');
+        cy.elements().style({
+          'background-color': '',
+          'line-color': '',
+          'opacity': '',
+          'text-opacity': ''
         });
-        cy.edges().forEach(edge => {
-          if (!edge.source().visible() || !edge.target().visible()) edge.hide();
-        });
-        showBtn.textContent = 'Show All';
-      } else {
+
+        if (global.resetAllClusters) global.resetAllClusters();
+
         cy.nodes().forEach(n => n.show());
         cy.edges().forEach(e => e.show());
-        showBtn.textContent = 'Show Only Clusters';
-      }
-    };
-  }
-  
-  if (clearBtn) {
-    clearBtn.onclick = function() {
-      // Clear highlights but keep clusters
-      cy.elements().removeClass('highlight faded');
-      cy.elements().style({ 'opacity': '', 'text-opacity': '' });
-      
-      // Reset any temporary highlighting styles
-      cy.nodes().forEach(node => {
-        if (!node.hasClass('cluster-color')) {
-          node.style('background-color', '');
-        }
-      });
-      cy.edges().forEach(edge => {
-        if (!edge.hasClass('cluster-color')) {
-          edge.style('line-color', '');
-        }
-      });
-      
-      // Show all nodes if in show-only mode
-      if (showOnly) {
-        cy.nodes().forEach(n => n.show());
-        cy.edges().forEach(e => e.show());
+
         showOnly = false;
         showBtn.textContent = 'Show Only Clusters';
-      }
-      
-      // Hide info panel
-      const infoPanel = document.getElementById('infoPanel');
-      if (infoPanel) infoPanel.style.display = 'none';
-      
-      // Hide cluster panel if open
-      const clusterPanel = document.getElementById('clusterPanel');
-      if (clusterPanel) clusterPanel.style.display = 'none';
-      
-      console.log('Cleared highlights and temporary selections');
-    };
-  }
-  
-  if (clearClustersBtn) {
-    clearClustersBtn.onclick = function() {
-      // Clear all clusters and reset everything
-      cy.elements().removeClass('highlight faded cluster-color');
-      cy.elements().style({ 
-        'background-color': '', 
-        'line-color': '', 
-        'opacity': '', 
-        'text-opacity': '' 
-      });
-      
-      // Reset all cluster data using global function
-      if (window.resetAllClusters) {
-        window.resetAllClusters();
-      }
-      
-      // Show all nodes
-      cy.nodes().forEach(n => n.show());
-      cy.edges().forEach(e => e.show());
-      
-      // Reset show only state
-      showOnly = false;
-      showBtn.textContent = 'Show Only Clusters';
-      
-      // Hide panels
-      const infoPanel = document.getElementById('infoPanel');
-      if (infoPanel) infoPanel.style.display = 'none';
-      
-      const clusterPanel = document.getElementById('clusterPanel');
-      if (clusterPanel) clusterPanel.style.display = 'none';
-      
-      console.log('Cleared all clusters and reset view');
-    };
-  }
-}
 
-function updateShowOnlyUI(cy) {
-  const showBtn = document.getElementById('showOnlyBtn');
-  if (showBtn) {
-    if (showOnly) {
-      showBtn.textContent = 'Show All';
-    } else {
-      showBtn.textContent = 'Show Only Clusters';
+        const infoPanel = document.getElementById('infoPanel');
+        if (infoPanel) infoPanel.style.display = 'none';
+        const clusterPanel = document.getElementById('clusterPanel');
+        if (clusterPanel) clusterPanel.style.display = 'none';
+
+        console.log('Cleared all clusters and reset view');
+      };
     }
   }
-}
 
-window.showOnlyControl = {
-  update: updateShowOnlyUI,
-  init: initShowOnlyControl
-};
+  function updateShowOnlyUI() {
+    const showBtn = document.getElementById('showOnlyBtn');
+    if (showBtn) {
+      showBtn.textContent = showOnly ? 'Show All' : 'Show Only Clusters';
+    }
+  }
+
+  global.showOnlyControl = {
+    update: updateShowOnlyUI,
+    init: initShowOnlyControl
+  };
+})(window);
+

--- a/styles.css
+++ b/styles.css
@@ -64,3 +64,74 @@ body { margin: 0; font-family: Arial, sans-serif; }
   opacity: 0.15;
   text-opacity: 0.1;
 }
+
+/* Generic button styles */
+.btn {
+  padding: 7px 12px;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+  font-size: 11px;
+}
+
+.btn-block {
+  width: 100%;
+  white-space: nowrap;
+}
+
+.btn-blue  { background: #2196F3; color: #fff; }
+.btn-green { background: #4CAF50; color: #fff; }
+.btn-orange{ background: #FF9800; color: #fff; }
+.btn-red   { background: #f44336; color: #fff; }
+.btn-default {
+  background: #f0f0f0;
+  border: 1px solid #ccc;
+  font-weight: normal;
+  color: #000;
+}
+
+/* Panel styles */
+.panel {
+  position: absolute;
+  background: rgba(255, 255, 255, 0.95);
+  padding: 10px;
+  border-radius: 8px;
+  box-shadow: 0 2px 12px rgba(0,0,0,0.1);
+  border: 1px solid #ddd;
+  z-index: 1005;
+  min-width: 160px;
+}
+
+.cluster-panel { min-width: 220px; }
+
+.depth-controls {
+  position: absolute;
+  background: #fff;
+  border: 1px solid #aaa;
+  border-radius: 6px;
+  padding: 4px 12px;
+  box-shadow: 0 2px 8px rgba(0,0,0,0.10);
+  z-index: 1003;
+}
+
+.panel-header {
+  font-size: 12px;
+  font-weight: bold;
+  color: #333;
+  margin-bottom: 8px;
+  text-align: center;
+  border-bottom: 1px solid #eee;
+  padding-bottom: 5px;
+}
+
+.control-group {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.depth-btn {
+  width: 32px;
+  font-size: 18px;
+}


### PR DESCRIPTION
## Summary
- add button and panel utility classes
- convert cluster control UI to use CSS classes and wrap logic in a module
- convert depth control to a module and use CSS styles
- convert show-only control to a module and style buttons/panels

## Testing
- `node --check clusterControl.js`
- `node --check depthControl.js`
- `node --check showOnlyControl.js`

------
https://chatgpt.com/codex/tasks/task_e_6886fe83cf98832c99bd4d693d8e515d